### PR TITLE
Add continuous integration for the test_espidf project

### DIFF
--- a/.github/workflows/platformio-testespidf.yml
+++ b/.github/workflows/platformio-testespidf.yml
@@ -6,14 +6,13 @@ on:
     paths:
     - 'test_espidf/*'
 
+defaults:
+  run:
+    working-directory: test_espidf
+
 jobs:
   build:
-
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        example: [test_espidf/src/]
-
     steps:
     - uses: actions/checkout@v2
     - name: Cache pip
@@ -34,8 +33,8 @@ jobs:
         python -m pip install --upgrade pip
         pip install --upgrade platformio
     - name: Install library dependencies
-      run: pio lib -g install 1
+      run: pio lib install
     - name: Run PlatformIO
-      run: pio ci --board=esp32dev --lib="test_espidf/include"
+      run: pio run -e esp32dev
       env:
-        PLATFORMIO_CI_SRC: ${{ matrix.example }}
+        PLATFORMIO_BUILD_CACHE_DIR: ~/.platformio/test_espidf_cache


### PR DESCRIPTION
This adds GitHub Actions CI for the test_espidf project. This will trigger upon pushes that affect the `test_espidf/` directory. I tried to get caching to work, but you'd need to cache the repo, and the `actions/checkout` action deletes the existing directory and I can't get it to stop. The relevant code is probably here: https://github.com/actions/checkout/blob/c952173edf28a2bd22e1a4926590c1ac39630461/src/git-directory-helper.ts

Currently builds take ~2min with some dependencies cached but none of the build files cached. I think this is fine for now.